### PR TITLE
Improve KOTS default YAML to include a port-forwarding application link [ch23377]

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -1,0 +1,11 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: "example-app"
+  labels:
+    app.kubernetes.io/name: "example-app"
+spec:
+  descriptor:
+    links:
+      - description: 'Example Application'
+        url: "http://example-nginx"

--- a/replicated-app.yaml
+++ b/replicated-app.yaml
@@ -9,3 +9,8 @@ spec:
     - deployment/example-nginx
   releaseNotes: |
     release notes
+  ports:
+    - serviceName: "example-nginx"
+      servicePort: 80
+      localPort: 8888
+      applicationUrl: "http://example-nginx"


### PR DESCRIPTION
Verified by creating an application with the exact same yaml and ensuring that the button works as expected (showing the NGINX page). 