### PR TITLE
update preflight and support-bundle yaml default YAML

### DIFF
--- a/preflight.yaml
+++ b/preflight.yaml
@@ -1,21 +1,29 @@
 apiVersion: troubleshoot.replicated.com/v1beta1
 kind: Preflight
 metadata:
-  name: example-preflight-checks
+  name: example-preflight-check
 spec:
   analyzers:
     - clusterVersion:
         outcomes:
           - fail:
               when: "< 1.13.0"
-              message: The application requires at Kubernetes 1.13.0 or later, and recommends 1.15.0.
+              message: This application requires at Kubernetes 1.13.0 or later, and recommends 1.15.0.
               uri: https://www.kubernetes.io
           - warn:
               when: "< 1.15.0"
               message: Your cluster meets the minimum version of Kubernetes, but we recommend you update to 1.15.0 or later.
               uri: https://kubernetes.io
           - pass:
+              when: ">= 1.15.0"
               message: Your cluster meets the recommended and required versions of Kubernetes.
+    - customResourceDefinition:
+        customResourceDefinitionName: ingressroutes.contour.heptio.com
+        outcomes:
+          - fail:
+              message: IngressRoutes CRD not found!
+          - pass:
+              message: IngressRoutes CRD found!
     - containerRuntime:
         outcomes:
           - pass:
@@ -23,8 +31,15 @@ spec:
               message: Docker container runtime was found.
           - fail:
               message: Did not find Docker container runtime.
+    - storageClass:
+        checkName: Required storage classes
+        storageClassName: "default"
+        outcomes:
+          - fail:
+              message: Could not find a storage class called default.
+          - pass:
+              message: All good on storage classes
     - distribution:
-        checkName: Check Kubernetes environment.
         outcomes:
           - fail:
               when: "== docker-desktop"
@@ -54,13 +69,50 @@ spec:
           - warn:
               message: Unable to determine the distribution of Kubernetes
     - nodeResources:
-        checkName: Total CPU Cores in the cluster is 2 or greater
+        checkName: Must have at least 3 nodes in the cluster, with 5 recommended
         outcomes:
-          - fail:
-              when: "sum(cpuCapacity) < 2"
-              message: The cluster must contain at least 2 cores
+        - fail:
+            when: "count() < 3"
+            message: This application requires at least 3 nodes.
+            uri: https://kurl.sh/docs/install-with-kurl/adding-nodes
+        - warn:
+            when: "count() < 5"
+            message: This application recommends at last 5 nodes.
+            uri: https://kurl.sh/docs/install-with-kurl/adding-nodes
+        - pass:
+            message: This cluster has enough nodes.
+    - nodeResources:
+        checkName: Every node in the cluster must have at least 10 GB of memory, with 32 GB recommended
+        outcomes:
+        - fail:
+            when: "min(memoryCapacity) < 10Gi"
+            message: All nodes must have at least 10 GB of memory.
+            uri: https://kurl.sh/docs/install-with-kurl/system-requirements
+        - warn:
+            when: "min(memoryCapacity) < 32Gi"
+            message: All nodes are recommended to have at least 32 GB of memory.
+            uri: https://kurl.sh/docs/install-with-kurl/system-requirements
+        - pass:
+            message: All nodes have at least 32 GB of memory.
+    - nodeResources:
+        checkName: Total CPU Cores in the cluster is 4 or greater
+        outcomes:
           - fail:
               when: "sum(cpuCapacity) < 4"
               message: The cluster must contain at least 4 cores
+              uri: https://kurl.sh/docs/install-with-kurl/system-requirements
           - pass:
-              message: There are at least 2 cores in the cluster
+              message: There are at least 4 cores in the cluster
+    - nodeResources:
+        checkName: Every node in the cluster must have at least 40 GB of ephemeral storage, with 100 GB recommended
+        outcomes:
+        - fail:
+            when: "min(ephemeralStorageCapacity) < 40Gi"
+            message: All nodes must have at least 40 GB of ephemeral storage.
+            uri: https://kurl.sh/docs/install-with-kurl/system-requirements
+        - warn:
+            when: "min(ephemeralStorageCapacity) < 100Gi"
+            message: All nodes are recommended to have at least 100 GB of ephemeral storage.
+            uri: https://kurl.sh/docs/install-with-kurl/system-requirements
+        - pass:
+            message: All nodes have at least 100 GB of ephemeral storage.

--- a/support-bundle.yaml
+++ b/support-bundle.yaml
@@ -1,11 +1,95 @@
 apiVersion: troubleshoot.replicated.com/v1beta1
-kind: Collector
+kind: SupportBundle
 metadata:
-  name: collector-sample
+  name: example-support-bundle
 spec:
-  collectors:
-    - clusterInfo: {}
-    - clusterResources: {}
+  analyzers:
+    - clusterVersion:
+        outcomes:
+          - fail:
+              when: "< 1.16.0"
+              message: The application requires at Kubernetes 1.16.0 or later
+              uri: https://kubernetes.io
+          - warn:
+              when: "< 1.17.0"
+              message: Your cluster meets the minimum version of Kubernetes, but we recommend you update to 1.17.0 or later.
+              uri: https://kubernetes.io
+          - pass:
+              message: Your cluster meets the recommended and required versions of Kubernetes.
+    - customResourceDefinition:
+        customResourceDefinitionName: rook
+        outcomes:
+          - fail:
+              message: The Rook CRD was not found in the cluster.
+          - pass:
+              message: Rook is installed and available.
+    - containerRuntime:
+        outcomes:
+          - fail:
+              when: "== docker"
+              message: The application does not support docker
+          - pass:
+              message: A supported container runtime was found
+    - storageClass:
+        checkName: Required storage classes
+        storageClassName: "microk8s-hostpath"
+        outcomes:
+          - fail:
+              message: The microk8s storage class thing was not found
+          - pass:
+              message: All good on storage classes
+    - nodeResources:
+        checkName: Must have at least 3 nodes in the cluster
+        outcomes:
+          - fail:
+              when: "count() < 3"
+              message: This application requires at least 3 nodes
+          - warn:
+              when: "count() < 5"
+              message: This application recommends at last 5 nodes.
+          - pass:
+              message: This cluster has enough nodes.
+    - nodeResources:
+        checkName: Total CPU Cores in the cluster is 4 or greater
+        outcomes:
+        - fail:
+            when: "sum(cpuCapacity) < 4"
+            message: The cluster must contain at least 4 cores
+        - pass:
+            message: There are at least 4 cores in the cluster
+    - nodeResources:
+        checkName: Each node must have at least 40 GB of ephemeral storage
+        outcomes:
+        - fail:
+            when: "min(ephemeralStorageCapacity) < 40Gi"
+            message: Noees in this cluster do not have at least 40 GB of ephemeral storage.
+            uri: https://kurl.sh/docs/install-with-kurl/system-requirements
+        - warn:
+            when: "min(ephemeralStorageCapacity) < 100Gi"
+            message: Nodes in this cluster are recommended to have at least 100 GB of ephemeral storage.
+            uri: https://kurl.sh/docs/install-with-kurl/system-requirements
+        - pass:
+            message: The nodes in this cluster have enough ephemeral storage.
+    - ingress:
+        namespace: default
+        ingressName: connect-to-me
+        outcomes:
+          - fail:
+              message: The ingress isn't ingressing
+          - pass:
+              message: All systems ok on ingress
+    - deploymentStatus:
+        name: api
+        namespace: default
+        outcomes:
+          - fail:
+              when: "< 1"
+              message: The API deployment does not have any ready replicas.
+          - warn:
+              when: "= 1"
+              message: The API deployment has only a single ready replica.
+          - pass:
+              message: There are multiple replicas of the API deployment ready.
     - logs:
         selector:
           - app=example


### PR DESCRIPTION
With the updates to the new troubleshoot site there are a few places that we are showing examples and the YAML for each of the examples is different. In an attempt to consolidate and use the same examples everywhere, this is the proposed new content for the preflight and support-bundle YAML files. for additional context see https://github.com/replicatedhq/troubleshoot.sh/issues/156