### PR TITLE
tweak ingress/ports to use Service NodePort in embedded

### DIFF
--- a/example-configmap.yaml
+++ b/example-configmap.yaml
@@ -13,19 +13,15 @@ data:
         <link href="styles.css" rel="stylesheet" type="text/css">
       </head>
       <body>
-        Hello from KOTS.
+        This is an example KOTS application.
         <p>This is text from a user config value: '{{repl ConfigOption "example_default_value"}}' </p>
         </br>
-        This is a hidden value:
-        </br>
-        <ul>
-          <li>Hidden Text: '{{repl ConfigOption "hidden_text"}}'</li>
-          <li>Hidden Text 2: '{{repl ConfigOption "hidden_text_two"}}'</li>
-        </ul>
+        This is a hidden value: '{{repl ConfigOption "hidden_text"}}'
       </body>
     </html>
   styles.css: |
     body {
+      text-align: center;
       background-color: rgb(224,224,224);
       font-family: Verdana, Arial, Helvetica, sans-serif;
       font-size: 100%;

--- a/example-deployment.yaml
+++ b/example-deployment.yaml
@@ -2,20 +2,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: example-nginx
+  name: nginx
   labels:
-    app: example
-    component: nginx
+    app: nginx
 spec:
   selector:
     matchLabels:
-      app: example
-      component: nginx
+      app: nginx
   template:
     metadata:
       labels:
-        app: example
-        component: nginx
+        app: nginx
       annotations:
         backup.velero.io/backup-volumes: nginx-content
     spec:

--- a/example-service.yaml
+++ b/example-service.yaml
@@ -1,15 +1,30 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+  annotations:
+    kots.io/when: '{{repl not IsKurl }}'
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+  selector:
+    app: nginx
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-nginx
+  name: nginx
   labels:
-    app: example
-    component: nginx
+    app: nginx
+  annotations:
+    kots.io/when: '{{repl IsKurl }}'
 spec:
-  type: ClusterIP
+  type: NodePort
   ports:
-  - port: 80
+    - port: 80
+      nodePort: 8888
   selector:
-    app: example
-    component: nginx
+    app: nginx

--- a/k8s-app.yaml
+++ b/k8s-app.yaml
@@ -1,0 +1,10 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: "nginx"
+spec:
+  descriptor:
+    links:
+      - description: Open The Application
+        # needs to match url in kots-app.yaml
+        url: "http://nginx"

--- a/k8s-app.yaml
+++ b/k8s-app.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   descriptor:
     links:
-      - description: Open The Application
-        # needs to match url in kots-app.yaml
+      - description: Open App
+        # needs to match applicationUrl in kots-app.yaml
         url: "http://nginx"

--- a/kots-app.yaml
+++ b/kots-app.yaml
@@ -2,14 +2,14 @@
 apiVersion: kots.io/v1beta1
 kind: Application
 metadata:
-  name: example-nginx
+  name: nginx
 spec:
   title: App Name
   icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/kubernetes/icon/color/kubernetes-icon-color.png
   statusInformers:
-    - deployment/example-nginx
+    - deployment/nginx
   ports:
-    - serviceName: "example-nginx"
+    - serviceName: "nginx"
       servicePort: 80
       localPort: 8888
-      applicationUrl: "http://example-nginx"
+      applicationUrl: "http://nginx"

--- a/kots-config.yaml
+++ b/kots-config.yaml
@@ -28,18 +28,13 @@ spec:
         rows: 5
       when: repl{{ ConfigOptionEquals "show_text_inputs" "1" }}
     - name: readonly_text_left
-      title: Readonly Text On the Left
+      title: Readonly Text
       type: text
       value: "{{repl RandomString 10}}"
       readonly: true
       when: repl{{ ConfigOptionEquals "show_text_inputs" "1" }}
     - name: hidden_text
       title: Secret Key
-      type: password
-      hidden: true
-      value: "{{repl RandomString 40}}"
-    - name: hidden_text_two
-      title: Public Key
       type: password
       hidden: true
       value: "{{repl RandomString 40}}"

--- a/kots-config.yaml
+++ b/kots-config.yaml
@@ -32,7 +32,6 @@ spec:
       type: text
       value: "{{repl RandomString 10}}"
       readonly: true
-      # affix: left
       when: repl{{ ConfigOptionEquals "show_text_inputs" "1" }}
     - name: hidden_text
       title: Secret Key

--- a/kots-preflight.yaml
+++ b/kots-preflight.yaml
@@ -1,7 +1,7 @@
 apiVersion: troubleshoot.sh/v1beta2
 kind: Preflight
 metadata:
-  name: example-preflight-checks
+  name: preflight-checks
 spec:
   analyzers:
     - clusterVersion:

--- a/kots-support-bundle.yaml
+++ b/kots-support-bundle.yaml
@@ -1,16 +1,12 @@
 apiVersion: troubleshoot.sh/v1beta2
 kind: SupportBundle
 metadata:
-  name: example-support-bundle
+  name: support-bundle
 spec:
   collectors:
     - clusterInfo: {}
     - clusterResources: {}
     - logs:
         selector:
-          - app=example
-          - component=nginx
+          - app=nginx
         namespace: '{{repl Namespace }}'
-        limits:
-          maxAge: 30d
-          maxLines: 10000


### PR DESCRIPTION
- create a conditional split to use one of two service objects based on embedded vs existing
- Use a NodePort in embedded cluster
- Update app labels to be more consistent with other projects we publish
- Add an "open app" button to the dashboard so that folks don't need to struggle with the arcane magic needed to make this feature work - they'll have a working example they can iterate on out of the box


Other PRs:

https://github.com/replicatedhq/replicated-starter-kots/pull/67
https://github.com/replicatedhq/replicated-docs/pull/555